### PR TITLE
lorri shell --cached

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,9 @@ pub struct ShellOptions {
     /// The .nix file in the current directory to use
     #[structopt(long = "shell-file", parse(from_os_str), default_value = "shell.nix")]
     pub nix_file: PathBuf,
+    /// If true, load environment from cache
+    #[structopt(long = "cached")]
+    pub cached: bool,
 }
 
 /// Options for the `start_user_shell_` subcommand.

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
         }
         Command::Shell(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;
-            shell::main(project)
+            shell::main(project, opts)
         }
         Command::StartUserShell_(opts) => {
             let (project, _guard) = with_project(&opts.nix_file)?;

--- a/src/ops/shell.rs
+++ b/src/ops/shell.rs
@@ -2,6 +2,8 @@
 
 use crate::builder;
 use crate::builder::RunStatus;
+use crate::cas::ContentAddressable;
+use crate::cli::ShellOptions;
 use crate::nix::CallOpts;
 use crate::ops::error::{ExitError, OpResult};
 use crate::project::{roots::Roots, Project};
@@ -9,6 +11,7 @@ use crossbeam_channel as chan;
 use slog_scope::debug;
 use std::io;
 use std::io::Write;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -22,8 +25,8 @@ use std::{env, thread};
 /// here just means whatever binary $SHELL points to. Concretely we get the following process tree:
 ///
 /// `lorri shell`
-/// ├── builds the project environment and writes a bash init script that loads the project
-/// │   environment
+/// ├── builds the project environment if --cached is false
+/// ├── writes a bash init script that loads the project environment
 /// ├── SPAWNS bash with the init script as its `--rcfile`
 /// │   └── EXECS `lorri start_user_shell_`
 /// │       ├── (*) performs shell-specific setup for $SHELL
@@ -34,12 +37,19 @@ use std::{env, thread};
 /// This setup allows lorri to support almost any shell with minimal additional work. Only the step
 /// marked (*) must be adjusted, and only in case we want to customize the shell, e.g. changing the
 /// way the prompt looks.
-pub fn main(project: Project) -> OpResult {
+pub fn main(project: Project, opts: ShellOptions) -> OpResult {
     let lorri = env::current_exe().expect("failed to determine lorri executable's path");
     let shell = env::var("SHELL").expect("lorri shell requires $SHELL to be set");
     debug!("using shell path {}", shell);
 
-    let mut bash_cmd = bash_cmd(&project)?;
+    let mut bash_cmd = bash_cmd(
+        if opts.cached {
+            cached_root(&project)?
+        } else {
+            build_root(&project)?
+        },
+        &project.cas,
+    )?;
     debug!("bash"; "command" => ?bash_cmd);
     bash_cmd
         .args(&[
@@ -59,8 +69,7 @@ pub fn main(project: Project) -> OpResult {
     Ok(())
 }
 
-/// Instantiates a `Command` to start bash.
-pub fn bash_cmd(project: &Project) -> Result<Command, ExitError> {
+fn build_root(project: &Project) -> Result<PathBuf, ExitError> {
     let (tx, rx) = chan::unbounded();
     thread::spawn(move || {
         eprint!("lorri: building environment");
@@ -79,21 +88,41 @@ pub fn bash_cmd(project: &Project) -> Result<Command, ExitError> {
 
     let run_result = builder::run(tx, &project.nix_file, &project.cas)
         .map_err(|e| ExitError::temporary(format!("build failed: {:?}", e)))?;
-    let build = match run_result.status {
-        RunStatus::Complete(build) => Roots::from_project(&project)
-            .create_roots(build)
-            .map_err(|e| ExitError::temporary(format!("rooting the environment failed: {:?}", e))),
-        e => Err(ExitError::temporary(format!("build failed: {:?}", e))),
-    }?;
+    Ok(Path::new(
+        match run_result.status {
+            RunStatus::Complete(build) => Roots::from_project(&project)
+                .create_roots(build)
+                .map_err(|e| {
+                    ExitError::temporary(format!("rooting the environment failed: {:?}", e))
+                }),
+            e => Err(ExitError::temporary(format!("build failed: {:?}", e))),
+        }?
+        .shell_gc_root
+        .as_os_str(),
+    )
+    .to_owned())
+}
 
-    let init_file = project
-        .cas
+fn cached_root(project: &Project) -> Result<PathBuf, ExitError> {
+    let root_paths = Roots::from_project(&project).paths();
+    if !root_paths.all_exist() {
+        Err(ExitError::temporary(
+            "project has not previously been built successfully",
+        ))
+    } else {
+        Ok(Path::new(root_paths.shell_gc_root.as_os_str()).to_owned())
+    }
+}
+
+/// Instantiates a `Command` to start bash.
+pub fn bash_cmd(project_root: PathBuf, cas: &ContentAddressable) -> Result<Command, ExitError> {
+    let init_file = cas
         .file_from_string(&format!(
             r#"
 EVALUATION_ROOT="{}"
 
 {}"#,
-            build.shell_gc_root,
+            project_root.display(),
             include_str!("direnv/envrc.bash")
         ))
         .expect("failed to write shell output");


### PR DESCRIPTION
<!--
Thank you for your contribution!

If this is the first time you are contributing to lorri, please take a look at:

https://github.com/target/lorri/CONTRIBUTING.md
-->

Addresses part 4 of https://github.com/target/lorri/issues/297. <!-- Please replace ISSUE by the issue number this pull request addresses. -->

## Overview

> Allow a user to open a cached lorri shell with no evaluation or build with `--cached`. If `lorri shell` fails (or takes a "long time"), suggest this option automatically. If the user runs with `--cached` without a cached evaluation, it should exit non-zero.

Todo:
- [ ] Suggest `--cached` on failure
- [ ] Suggest `--cached` if build takes a long time

<!--
Explain the approach you took to resolving the issue and provide necessary context.

There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory
and include good commit messages.

See https://github.com/target/lorri/CONTRIBUTING.md for more on how to structure a pull request.
-->

## Checklist

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

